### PR TITLE
fix[#3]: preserve and record changes on edit

### DIFF
--- a/src/scripts/apps/AuditLogApp.ts
+++ b/src/scripts/apps/AuditLogApp.ts
@@ -103,6 +103,7 @@ export default class AuditLogApp extends SvelteApplicationMixin(
           valueChanged: change.valueChanged,
           oldValue: change.oldValue,
           newValue: change.newValue,
+          result: change.newValue,
           diff: diffString,
         };
       })

--- a/src/scripts/apps/TrackedItemApp.ts
+++ b/src/scripts/apps/TrackedItemApp.ts
@@ -122,7 +122,24 @@ export default class TrackedItemApp extends SvelteApplicationMixin(
     form: HTMLFormElement,
     formData: FormDataExtended,
   ) {
-    const newItem = createTrackedItem(formData.object as any);
+    const changes = this.activity?.changes ?? [];
+    const newItem = createTrackedItem({ ...formData.object, changes } as any);
+
+    if (this.activity && newItem.progress !== this.activity.progress) {
+      const newChange = {
+        id: foundry.utils.randomID(),
+        timestamp: new Date(),
+        actionName: localize("downtime-dnd5e.AdjustProgressValue") + " (=)",
+        valueChanged: "progress",
+        oldValue: this.activity.progress,
+        newValue: newItem.progress,
+        user: game.user.name,
+        note: "",
+      } as Downtime.AuditLogV1;
+
+      changes.push(newChange);
+    }
+
     const activities = this.world
       ? getWorldActivities()
       : getActorActivities(this.actor);


### PR DESCRIPTION
fixes #3

Changes now preserved when editing Activity. Additionally, records changes to progress while editting

Additionally shows results in audit log.